### PR TITLE
Feature/#8 포켓몬 상세 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import Home from "@/page/Home";
 import Pokedex from "@/page/pokedex/Pokedex";
+import PokemonDetail from "@/page/pokemon/detail/PokemonDetail";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 function App() {
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/pokedex" element={<Pokedex />} />
+        <Route path="/pokemon/detail/:id" element={<PokemonDetail />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/features/pokemon/PokemonCard.tsx
+++ b/src/components/features/pokemon/PokemonCard.tsx
@@ -1,5 +1,6 @@
 import PokemonCardS from "@/components/features/pokemon/PokemonCard.styles";
 import { Pokemon } from "@/types/pokemon.dto";
+import { useNavigate } from "react-router-dom";
 
 interface PokemonCardProps {
   pokemon: Omit<Pokemon, "description" | "types">;
@@ -12,15 +13,28 @@ export default function PokemonCard({
   cardType,
   onActionClick,
 }: PokemonCardProps) {
-  function handleButtonClick(
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-  ) {
+  const navigate = useNavigate();
+
+  function handleButtonClick(e: React.MouseEvent<HTMLButtonElement>) {
     e.preventDefault();
+    e.stopPropagation();
     onActionClick(pokemon.id);
   }
 
+  function handleGoDetailButtonClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+
+    const scrollPosition = window.scrollY;
+    navigate(`/pokemon/detail/${pokemon.id}`, {
+      state: { scrollPosition },
+    });
+  }
+
   return (
-    <PokemonCardS.Container to={`/pokemon/detail/${pokemon.id}`}>
+    <PokemonCardS.Container
+      to={`/pokemon/detail/${pokemon.id}`}
+      onClick={handleGoDetailButtonClick}
+    >
       <PokemonCardS.Image src={pokemon.imageUrl} alt={pokemon.name} />
       <PokemonCardS.Name>{pokemon.name}</PokemonCardS.Name>
       <PokemonCardS.Description>

--- a/src/components/features/pokemon/PokemonList.tsx
+++ b/src/components/features/pokemon/PokemonList.tsx
@@ -28,6 +28,7 @@ export default function PokemonList({
     <PokemonListS.Container>
       {POKEMON_DATA.map((pokemon) => (
         <PokemonCard
+          key={pokemon.id}
           pokemon={pokemon}
           cardType="ADD"
           onActionClick={handleAddPokemonClick}

--- a/src/page/pokemon/detail/PokemonDetail.tsx
+++ b/src/page/pokemon/detail/PokemonDetail.tsx
@@ -1,0 +1,6 @@
+import { useParams } from "react-router-dom";
+
+export default function PokemonDetail() {
+  const pokemonId = useParams().id;
+  return <h1>PokemonDetail {pokemonId}</h1>;
+}

--- a/src/page/pokemon/detail/PokemonDetail.tsx
+++ b/src/page/pokemon/detail/PokemonDetail.tsx
@@ -1,6 +1,48 @@
-import { useParams } from "react-router-dom";
+import { POKEMON_DATA } from "@/mocks";
+import { useEffect } from "react";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
 
 export default function PokemonDetail() {
-  const pokemonId = useParams().id;
-  return <h1>PokemonDetail {pokemonId}</h1>;
+  const pokemonId = Number(useParams().id);
+  const pokemon = POKEMON_DATA.find((pokemon) => pokemon.id === pokemonId);
+
+  const { state } = useLocation();
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (state?.scrollPosition) {
+        window.scrollTo(0, state.scrollPosition);
+      }
+    };
+  }, [state]);
+
+  return (
+    <PokemonDetailS.Container>
+      <img src={pokemon?.imageUrl} alt={pokemon?.name} />
+      <h3>{pokemon?.name}</h3>
+      <p>타입: {pokemon?.types.join(", ")}</p>
+      <p>{pokemon?.description}</p>
+      <Link
+        to=".."
+        onClick={(e) => {
+          e.preventDefault();
+          handleBack();
+        }}
+      >
+        뒤돌아가기
+      </Link>
+    </PokemonDetailS.Container>
+  );
 }
+
+const Container = styled.main``;
+
+const PokemonDetailS = {
+  Container,
+};


### PR DESCRIPTION
## 💡 관련이슈
- close #8 

## 🍀 작업 요약
- 포켓몬 상세 페이지 UI 구현
- 상세 페이지에서 다시 도감 페이지로 돌아갈 때, 이전 scroll 위치로 이동하도록 구현

## 💬 리뷰 요구 사항
- 리뷰 예상 시간 : `10분`

## 💛 미리보기
![2025-02-048 26 31-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/11ba50a9-6099-4853-9797-16a5db297114)

