### PR TITLE
Feature/#26 리렌더링 성능 개선

### DIFF
--- a/src/components/features/pokemon-detail/PokemonActionButtons.tsx
+++ b/src/components/features/pokemon-detail/PokemonActionButtons.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import Button from "@/components/common/Button";
 import ButtonLink from "@/components/common/ButtonLink";
@@ -13,18 +12,12 @@ export default function PokemonActionButtons({
 }: PokemonActionButtonsProps) {
   const { isChose, togglePokemon } = usePokemonsStore();
 
-  const navigate = useNavigate();
-  function handleDexLinkButtonClick(e: React.MouseEvent<HTMLAnchorElement>) {
-    e.preventDefault();
-    navigate("/pokemon", { state: { focusedId: pokemonId } });
-  }
-
   return (
     <Buttons>
       <Button onClick={() => togglePokemon(pokemonId)}>
         {isChose(pokemonId) ? "제거하기" : "추가하기"}
       </Button>
-      <ButtonLink onClick={handleDexLinkButtonClick} $variant="outline">
+      <ButtonLink href="/pokemon" $variant="outline">
         뒤로가기
       </ButtonLink>
     </Buttons>

--- a/src/components/features/pokemon-detail/PokemonActionButtons.tsx
+++ b/src/components/features/pokemon-detail/PokemonActionButtons.tsx
@@ -11,7 +11,7 @@ interface PokemonActionButtonsProps {
 export default function PokemonActionButtons({
   pokemonId,
 }: PokemonActionButtonsProps) {
-  const { isChose, handlePokemonStoreAction } = usePokemonsStore();
+  const { isChose, togglePokemon } = usePokemonsStore();
 
   const navigate = useNavigate();
   function handleDexLinkButtonClick(e: React.MouseEvent<HTMLAnchorElement>) {
@@ -21,7 +21,7 @@ export default function PokemonActionButtons({
 
   return (
     <Buttons>
-      <Button onClick={() => handlePokemonStoreAction(pokemonId)}>
+      <Button onClick={() => togglePokemon(pokemonId)}>
         {isChose(pokemonId) ? "제거하기" : "추가하기"}
       </Button>
       <ButtonLink onClick={handleDexLinkButtonClick} $variant="outline">

--- a/src/components/features/pokemon-detail/PokemonActionButtons.tsx
+++ b/src/components/features/pokemon-detail/PokemonActionButtons.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import Button from "@/components/common/Button";
+import ButtonLink from "@/components/common/ButtonLink";
+import usePokemonsStore from "@/lib/hooks/usePokemonsStore";
+
+interface PokemonActionButtonsProps {
+  pokemonId: number;
+}
+
+export default function PokemonActionButtons({
+  pokemonId,
+}: PokemonActionButtonsProps) {
+  const { isChose, handlePokemonStoreAction } = usePokemonsStore();
+
+  const navigate = useNavigate();
+  function handleDexLinkButtonClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    navigate("/pokemon", { state: { focusedId: pokemonId } });
+  }
+
+  return (
+    <Buttons>
+      <Button onClick={() => handlePokemonStoreAction(pokemonId)}>
+        {isChose(pokemonId) ? "제거하기" : "추가하기"}
+      </Button>
+      <ButtonLink onClick={handleDexLinkButtonClick} $variant="outline">
+        뒤로가기
+      </ButtonLink>
+    </Buttons>
+  );
+}
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+`;

--- a/src/components/features/pokemon/PokemonCard.tsx
+++ b/src/components/features/pokemon/PokemonCard.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Typography from "@/components/common/Typography";
 import PokemonCardS from "@/components/features/pokemon/PokemonCard.styled";
 import { formatNumber } from "@/lib/utils/format.util";
@@ -9,7 +10,7 @@ interface PokemonCardProps extends React.HTMLAttributes<HTMLDivElement> {
   isFocused: boolean;
 }
 
-export default function PokemonCard({
+function PokemonCard({
   pokemon,
   isChose,
   isFocused,
@@ -31,3 +32,5 @@ export default function PokemonCard({
     </PokemonCardS.Container>
   );
 }
+
+export default React.memo(PokemonCard);

--- a/src/components/features/pokemon/PokemonDashboard.tsx
+++ b/src/components/features/pokemon/PokemonDashboard.tsx
@@ -1,51 +1,26 @@
-import React, { SetStateAction } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { toast } from "react-toastify";
+import React from "react";
 import PokemonDashboardS from "@/components/features/pokemon/PokemonDashboard.styled";
 import PokemonFocusedCard from "@/components/features/pokemon/PokemonFocusedCard";
 import ButtonLink from "@/components/common/ButtonLink";
 import Button from "@/components/common/Button";
-import { RootState } from "@/store/redux";
-import { addPokemon, deletePokemon } from "@/store/pokemons.slice";
 import { MAX_POKEMON_COUNT } from "@/constants";
-import { POKEMON_DATA } from "@/mocks";
+import usePokemonsStore from "@/lib/hooks/usePokemonsStore";
+import useFocusedPokemonStore from "@/lib/hooks/useFocusedPokemonStore";
 
-export interface PokemonDashboardProps {
-  focusedId: number;
-  setFocusedId: React.Dispatch<SetStateAction<number>>;
-}
+export default function PokemonDashboard() {
+  const { chosePokemons, togglePokemon, isChose } = usePokemonsStore();
+  const { focusedPokemon, updateFocusedPokemon } = useFocusedPokemonStore();
 
-export default function PokemonDashboard({
-  focusedId,
-  setFocusedId,
-}: PokemonDashboardProps) {
-  const dispatch = useDispatch();
-
-  const chosePokemons = useSelector((state: RootState) => state.pokemons);
   const restPokemons = Array.from(
     { length: MAX_POKEMON_COUNT - chosePokemons.length },
     (_, i) => i
   );
-  const focusedPokemon = POKEMON_DATA.find((p) => p.id === focusedId);
-  const isChose = chosePokemons.some((cp) => cp.id === focusedId);
 
   function handleChosePokemonHover(e: React.MouseEvent<HTMLDivElement>) {
     const chosePokemon = (e.target as HTMLElement).closest("a");
     if (!chosePokemon) return;
     const pokemonId = Number(chosePokemon.id.split("-").at(-1));
-    setFocusedId(pokemonId);
-  }
-
-  function handleActionPokemonClick() {
-    if (!focusedPokemon) return;
-    if (isChose) {
-      dispatch(deletePokemon(focusedPokemon.id));
-      return toast.info(`${focusedPokemon.name} 아(야), 잘 가!`);
-    }
-    if (chosePokemons.length >= MAX_POKEMON_COUNT)
-      return toast.error("더 이상 선택할 수 없습니다.");
-    dispatch(addPokemon(focusedPokemon));
-    return toast.info(`와! ${focusedPokemon.name} 을(를) 포획했다!`);
+    updateFocusedPokemon(pokemonId);
   }
 
   return (
@@ -61,7 +36,7 @@ export default function PokemonDashboard({
               <img src={p.imageUrl} alt={p.name} />
             </PokemonDashboardS.PokemonLink>
           ))}
-          {restPokemons.reverse().map((key) => (
+          {restPokemons.map((key) => (
             <PokemonDashboardS.EmptyImg
               key={key}
               src="/pokemon_ball.png"
@@ -70,15 +45,18 @@ export default function PokemonDashboard({
           ))}
         </PokemonDashboardS.GridBox>
         <PokemonDashboardS.Buttons>
-          <Button onClick={handleActionPokemonClick}>
-            {isChose ? "제거하기" : "추가하기"}
+          <Button onClick={() => togglePokemon(focusedPokemon.id)}>
+            {isChose(focusedPokemon.id) ? "제거하기" : "추가하기"}
           </Button>
-          <ButtonLink href={`/pokemon/detail/${focusedId}`} $variant="outline">
+          <ButtonLink
+            href={`/pokemon/detail/${focusedPokemon.id}`}
+            $variant="outline"
+          >
             상세보기
           </ButtonLink>
         </PokemonDashboardS.Buttons>
       </div>
-      <PokemonFocusedCard focusedId={focusedId} />
+      <PokemonFocusedCard focusedId={focusedPokemon.id} />
     </PokemonDashboardS.Container>
   );
 }

--- a/src/components/features/pokemon/PokemonList.tsx
+++ b/src/components/features/pokemon/PokemonList.tsx
@@ -1,62 +1,31 @@
-import React, { SetStateAction, useEffect, useRef } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { toast } from "react-toastify";
+import React, { useEffect, useRef } from "react";
 import PokemonListS from "@/components/features/pokemon/PokemonList.styled";
 import PokemonCard from "@/components/features/pokemon/PokemonCard";
 import { useGridColumnCount } from "@/lib/hooks/useGridColumCount";
-import { addPokemon, deletePokemon } from "@/store/pokemons.slice";
-import { RootState } from "@/store/redux";
-import { MAX_POKEMON_COUNT } from "@/constants";
+import usePokemonsStore from "@/lib/hooks/usePokemonsStore";
+import useFocusedPokemonStore from "@/lib/hooks/useFocusedPokemonStore";
 import { POKEMON_DATA } from "@/mocks";
 
 import { executeKeyAction, getKeyMapping } from "@/types/keyAction.type";
 
-export interface PokemonListProps {
-  focusedId: number;
-  setFocusedId: React.Dispatch<SetStateAction<number>>;
-}
-
-export default function PokemonList({
-  focusedId,
-  setFocusedId,
-}: PokemonListProps) {
+export default function PokemonList() {
   const { gridRef, columnCount } = useGridColumnCount();
   const innerContainerRef = useRef<HTMLDivElement>(null);
-  const chosePokemons = useSelector((state: RootState) => state.pokemons);
-  const dispatch = useDispatch();
-
-  const pokemonsWithSelect = POKEMON_DATA.map((p) =>
-    chosePokemons.some((cp) => cp.id === p.id)
-      ? { ...p, isChose: true }
-      : { ...p, isChose: false }
-  );
-  const maxId = pokemonsWithSelect.at(-1)?.id || 0;
+  const { togglePokemon, isChose } = usePokemonsStore();
+  const { focusedPokemon, updateFocusedPokemon } = useFocusedPokemonStore();
 
   function handleArrowKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     e.preventDefault();
     const actionKey = getKeyMapping(e.key);
     if (!actionKey) return;
+
     executeKeyAction(
       actionKey,
-      maxId,
       columnCount,
-      setFocusedId,
-      handleEnterAction
+      focusedPokemon.id,
+      updateFocusedPokemon,
+      togglePokemon
     );
-  }
-
-  function handleEnterAction() {
-    const focusedPokemon = pokemonsWithSelect.find((p) => p.id === focusedId);
-    if (!focusedPokemon) return;
-
-    if (focusedPokemon.isChose) {
-      dispatch(deletePokemon(focusedPokemon.id));
-      return toast.info(`${focusedPokemon.name} 아(야), 잘 가!`);
-    }
-    if (chosePokemons.length >= MAX_POKEMON_COUNT)
-      return toast.error("더 이상 선택할 수 없습니다.");
-    dispatch(addPokemon(focusedPokemon));
-    return toast.info(`와! ${focusedPokemon.name} 을(를) 포획했다!`);
   }
 
   function handleCardClick(e: React.MouseEvent<HTMLDivElement>) {
@@ -64,7 +33,7 @@ export default function PokemonList({
     if (!card) return;
 
     const pokemonId = Number(card.id.split("-").at(-1));
-    setFocusedId(pokemonId);
+    updateFocusedPokemon(pokemonId);
   }
 
   useEffect(() => {
@@ -74,8 +43,8 @@ export default function PokemonList({
   useEffect(() => {
     if (innerContainerRef.current)
       innerContainerRef.current.scrollTop =
-        Math.floor((focusedId - 1) / columnCount) * 200;
-  }, [focusedId, columnCount]);
+        Math.floor((focusedPokemon.id - 1) / columnCount) * 200;
+  }, [focusedPokemon.id, columnCount]);
 
   return (
     <PokemonListS.Container
@@ -84,12 +53,12 @@ export default function PokemonList({
       onBlur={() => innerContainerRef.current?.focus()}
     >
       <PokemonListS.Grid ref={gridRef} onClick={handleCardClick}>
-        {pokemonsWithSelect.map((pokemon) => (
+        {POKEMON_DATA.map((pokemon) => (
           <PokemonCard
             key={pokemon.id}
             pokemon={pokemon}
-            isChose={pokemon.isChose}
-            isFocused={focusedId === pokemon.id}
+            isChose={isChose(pokemon.id)}
+            isFocused={focusedPokemon.id === pokemon.id}
             id={`pokemon-card-${pokemon.id}`}
           />
         ))}

--- a/src/lib/hooks/useFocusedPokemonStore.ts
+++ b/src/lib/hooks/useFocusedPokemonStore.ts
@@ -1,0 +1,21 @@
+import { POKEMON_DATA } from "@/mocks";
+import { updatePokemon } from "@/store/focusedPokemon.slice";
+import { RootState } from "@/store/redux";
+import { useDispatch, useSelector } from "react-redux";
+
+export default function useFocusedPokemonStore() {
+  const focusedPokemon = useSelector(
+    (state: RootState) => state.focusedPokemon
+  );
+  const dispatch = useDispatch();
+  console.log(focusedPokemon.id, focusedPokemon.name);
+
+  function updateFocusedPokemon(pokemonId: number) {
+    const pokemon = POKEMON_DATA.find((p) => p.id === pokemonId);
+    if (!pokemon) return;
+
+    dispatch(updatePokemon(pokemon));
+  }
+
+  return { focusedPokemon, updateFocusedPokemon };
+}

--- a/src/lib/hooks/usePokemonsStore.ts
+++ b/src/lib/hooks/usePokemonsStore.ts
@@ -1,0 +1,32 @@
+import { MAX_POKEMON_COUNT } from "@/constants";
+import { POKEMON_DATA } from "@/mocks";
+import { addPokemon, deletePokemon } from "@/store/pokemons.slice";
+import { RootState } from "@/store/redux";
+import { useDispatch, useSelector } from "react-redux";
+import { toast } from "react-toastify";
+
+export default function usePokemonsStore() {
+  const chosePokemons = useSelector((state: RootState) => state.pokemons);
+  const dispatch = useDispatch();
+
+  function handlePokemonStoreAction(pokemonId: number) {
+    const pokemon = POKEMON_DATA.find((p) => p.id === pokemonId);
+    if (!pokemon) return;
+
+    const isChose = chosePokemons.some((cp) => cp.id === pokemon.id);
+    if (isChose) {
+      dispatch(deletePokemon(pokemon.id));
+      return toast.info(`${pokemon.name} 아(야), 잘 가!`);
+    }
+    if (chosePokemons.length >= MAX_POKEMON_COUNT)
+      return toast.error("더 이상 선택할 수 없습니다.");
+    dispatch(addPokemon(pokemon));
+    return toast.info(`와! ${pokemon.name} 을(를) 포획했다!`);
+  }
+
+  function isChose(pokemonId: number) {
+    return chosePokemons.some((cp) => cp.id === pokemonId);
+  }
+
+  return { chosePokemons, handlePokemonStoreAction, isChose };
+}

--- a/src/lib/hooks/usePokemonsStore.ts
+++ b/src/lib/hooks/usePokemonsStore.ts
@@ -9,7 +9,7 @@ export default function usePokemonsStore() {
   const chosePokemons = useSelector((state: RootState) => state.pokemons);
   const dispatch = useDispatch();
 
-  function handlePokemonStoreAction(pokemonId: number) {
+  function togglePokemon(pokemonId: number) {
     const pokemon = POKEMON_DATA.find((p) => p.id === pokemonId);
     if (!pokemon) return;
 
@@ -28,5 +28,5 @@ export default function usePokemonsStore() {
     return chosePokemons.some((cp) => cp.id === pokemonId);
   }
 
-  return { chosePokemons, handlePokemonStoreAction, isChose };
+  return { chosePokemons, togglePokemon, isChose };
 }

--- a/src/page/pokemon/Pokemon.tsx
+++ b/src/page/pokemon/Pokemon.tsx
@@ -1,21 +1,16 @@
-import { useState } from "react";
-import { useLocation } from "react-router-dom";
 import PokemonPageS from "@/page/pokemon/Pokemon.styled";
 import PokemonList from "@/components/features/pokemon/PokemonList";
 import PokemonDashboard from "@/components/features/pokemon/PokemonDashboard";
 import PokemonUsageGuideModal from "@/components/features/pokemon/PokemonUsageGuideModal";
 
 export default function Pokemon() {
-  const { state } = useLocation();
-  const [focusedId, setFocusedId] = useState<number>(state?.focusedId ?? 1);
-
   return (
     <>
       <PokemonPageS.Container>
         <PokemonPageS.Title>choose your Pokémon</PokemonPageS.Title>
         <hr />
-        <PokemonList focusedId={focusedId} setFocusedId={setFocusedId} />
-        <PokemonDashboard focusedId={focusedId} setFocusedId={setFocusedId} />
+        <PokemonList />
+        <PokemonDashboard />
       </PokemonPageS.Container>
       <PokemonUsageGuideModal />
     </>

--- a/src/page/pokemon/detail/PokemonDetail.tsx
+++ b/src/page/pokemon/detail/PokemonDetail.tsx
@@ -1,22 +1,15 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { MdArrowBackIosNew, MdArrowForwardIos } from "react-icons/md";
-import { useDispatch, useSelector } from "react-redux";
-import { toast } from "react-toastify";
 import Typography from "@/components/common/Typography";
 import ButtonLink from "@/components/common/ButtonLink";
-import Button from "@/components/common/Button";
 import PokemonDetailS from "@/page/pokemon/detail/PokemonDetail.styled";
-import { addPokemon, deletePokemon } from "@/store/pokemons.slice";
-import { RootState } from "@/store/redux";
 import { formatNumber } from "@/lib/utils/format.util";
-import { MAX_POKEMON_COUNT } from "@/constants";
 import { POKEMON_DATA } from "@/mocks";
+import PokemonActionButtons from "@/components/features/pokemon-detail/PokemonActionButtons";
 
 export default function PokemonDetail() {
   const pokemonId = Number(useParams().id);
   const pokemon = POKEMON_DATA.find((pokemon) => pokemon.id === pokemonId);
-  const chosePokemons = useSelector((state: RootState) => state.pokemons);
-  const dispatch = useDispatch();
   const maxId = POKEMON_DATA.at(-1)?.id || 0;
 
   const navigate = useNavigate();
@@ -24,24 +17,6 @@ export default function PokemonDetail() {
   if (!pokemon) {
     navigate(-1);
     return null;
-  }
-  const isChose = chosePokemons.some((cp) => cp.id === pokemon.id);
-
-  function handleActionPokemonClick() {
-    if (!pokemon) return;
-    if (isChose) {
-      dispatch(deletePokemon(pokemon.id));
-      return toast.info(`${pokemon.name} 아(야), 잘 가!`);
-    }
-    if (chosePokemons.length >= MAX_POKEMON_COUNT)
-      return toast.error("더 이상 선택할 수 없습니다.");
-    dispatch(addPokemon(pokemon));
-    return toast.info(`와! ${pokemon.name} 을(를) 포획했다!`);
-  }
-
-  function handleDexLinkButtonClick(e: React.MouseEvent<HTMLAnchorElement>) {
-    e.preventDefault();
-    navigate("/pokemon", { state: { focusedId: pokemonId } });
   }
 
   return (
@@ -77,14 +52,7 @@ export default function PokemonDetail() {
         </ButtonLink>
       </PokemonDetailS.Body>
       <Typography>{pokemon.description}</Typography>
-      <PokemonDetailS.Buttons>
-        <Button onClick={handleActionPokemonClick}>
-          {isChose ? "제거하기" : "추가하기"}
-        </Button>
-        <ButtonLink onClick={handleDexLinkButtonClick} $variant="outline">
-          뒤로가기
-        </ButtonLink>
-      </PokemonDetailS.Buttons>
+      <PokemonActionButtons pokemonId={pokemon.id} />
     </PokemonDetailS.Container>
   );
 }

--- a/src/page/pokemon/detail/PokemonDetail.tsx
+++ b/src/page/pokemon/detail/PokemonDetail.tsx
@@ -1,18 +1,25 @@
+import { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { MdArrowBackIosNew, MdArrowForwardIos } from "react-icons/md";
 import Typography from "@/components/common/Typography";
 import ButtonLink from "@/components/common/ButtonLink";
+import PokemonActionButtons from "@/components/features/pokemon-detail/PokemonActionButtons";
 import PokemonDetailS from "@/page/pokemon/detail/PokemonDetail.styled";
 import { formatNumber } from "@/lib/utils/format.util";
+import useFocusedPokemonStore from "@/lib/hooks/useFocusedPokemonStore";
 import { POKEMON_DATA } from "@/mocks";
-import PokemonActionButtons from "@/components/features/pokemon-detail/PokemonActionButtons";
 
 export default function PokemonDetail() {
+  const { updateFocusedPokemon } = useFocusedPokemonStore();
   const pokemonId = Number(useParams().id);
   const pokemon = POKEMON_DATA.find((pokemon) => pokemon.id === pokemonId);
   const maxId = POKEMON_DATA.at(-1)?.id || 0;
 
   const navigate = useNavigate();
+
+  useEffect(() => {
+    updateFocusedPokemon(pokemonId);
+  }, [updateFocusedPokemon, pokemonId]);
 
   if (!pokemon) {
     navigate(-1);

--- a/src/store/focusedPokemon.slice.ts
+++ b/src/store/focusedPokemon.slice.ts
@@ -8,7 +8,7 @@ const focusedPokemonSlice = createSlice({
   name: "focusedPokemon",
   initialState,
   reducers: {
-    updatePokemon: (state, action: PayloadAction<Pokemon>) => action.payload,
+    updatePokemon: (_state, action: PayloadAction<Pokemon>) => action.payload,
   },
 });
 

--- a/src/store/focusedPokemon.slice.ts
+++ b/src/store/focusedPokemon.slice.ts
@@ -1,0 +1,16 @@
+import { POKEMON_DATA } from "@/mocks";
+import { Pokemon } from "@/types/pokemon.dto";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+const initialState: Pokemon = POKEMON_DATA[0];
+
+const focusedPokemonSlice = createSlice({
+  name: "focusedPokemon",
+  initialState,
+  reducers: {
+    updatePokemon: (state, action: PayloadAction<Pokemon>) => action.payload,
+  },
+});
+
+export const { updatePokemon } = focusedPokemonSlice.actions;
+export default focusedPokemonSlice.reducer;

--- a/src/store/redux.ts
+++ b/src/store/redux.ts
@@ -1,16 +1,18 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { persistReducer, persistStore } from "redux-persist";
-import pokemonsReducer from "@/store/pokemons.slice";
 import localStorage from "redux-persist/lib/storage";
+import pokemonsReducer from "@/store/pokemons.slice";
+import focusedPokemonReducer from "@/store/focusedPokemon.slice";
 
 const persistConfig = {
   key: "root",
   storage: localStorage,
-  whitelist: ["pokemons"],
+  whitelist: ["pokemons", "focusedPokemon"],
 };
 
 export const rootReducer = combineReducers({
   pokemons: pokemonsReducer,
+  focusedPokemon: focusedPokemonReducer,
 });
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);

--- a/src/types/keyAction.type.ts
+++ b/src/types/keyAction.type.ts
@@ -1,4 +1,4 @@
-import { SetStateAction } from "react";
+import { POKEMON_DATA } from "@/mocks";
 
 export const KeyAction = {
   UP: "UP",
@@ -27,23 +27,32 @@ export function getKeyMapping(key: string): KeyActionType | null {
 
 export function executeKeyAction(
   key: KeyActionType,
-  maxId: number,
   column: number,
-  setFocusedId: React.Dispatch<SetStateAction<number>>,
-  onEnterAction: () => void
+  focusedId: number,
+  updateFocusedPokemon: (id: number) => void,
+  togglePokemon: (id: number) => void
 ) {
+  const maxId = POKEMON_DATA.at(-1)?.id ?? -1;
+  let nextFocusedId = -1;
   switch (key) {
     case KeyAction.RIGHT:
-      return setFocusedId((prev) => (prev + 1 <= maxId ? prev + 1 : 1));
+      nextFocusedId = focusedId + 1 <= maxId ? focusedId + 1 : 1;
+      break;
     case KeyAction.LEFT:
-      return setFocusedId((prev) => (prev - 1 > 0 ? prev - 1 : maxId));
+      nextFocusedId = focusedId - 1 > 0 ? focusedId - 1 : maxId;
+      break;
     case KeyAction.UP:
-      return setFocusedId((prev) => (prev + maxId - column) % maxId || maxId);
+      nextFocusedId = (focusedId + maxId - column) % maxId || maxId;
+      break;
     case KeyAction.DOWN:
-      return setFocusedId((prev) => (prev + column) % maxId || maxId);
+      nextFocusedId = (focusedId + column) % maxId || maxId;
+      break;
     case KeyAction.ENTER:
-      return onEnterAction();
+      return togglePokemon(focusedId);
     default:
       break;
   }
+
+  if (nextFocusedId === -1) return;
+  updateFocusedPokemon(nextFocusedId);
 }


### PR DESCRIPTION
## 💡 관련이슈
- close #26 

## 🍀 작업 요약
- focusedId를 redux 내에서 관리하도록 변경
- redux 내에 저장된 pokemons와 focusedPokemon을 관리하기 쉽도록 훅으로 생성
- 리렌더링을 최소화하도록 코드 개선

## 💬 리뷰 요구 사항
- 어떻게 하면 더 효율적일 수 있을까유?
- 리뷰 예상 시간 : `15분`

## 💛 미리보기
### 코드 개선 전
- 포켓몬 도감 페이지
![2025-02-106 48 39-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/839b760b-0b0d-4c69-a5b6-382317862c1b)


- 포켓몬 상세 페이지
![2025-02-106 49 32-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/37b140e6-57dc-4d3b-87a3-1ca3f505ff4c)


### 코드 개선 후
- 포켓몬 도감 페이지
![2025-02-106 46 53-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/005c119f-8f24-428c-860e-6975c17185f9)

- 포켓몬 상세 페이지
![2025-02-106 47 44-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b5014b23-5538-4352-8183-5be1cde6f0b3)



